### PR TITLE
Add earnings checker script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
+# Stock Identifier
 
+This repository contains a small script that queries the [Financial Modeling Prep](https://financialmodelingprep.com/) API for companies releasing earnings on the current day and prints those that beat their EPS estimates.
+
+## Setup
+
+1. Create a `.env` file based on `env.example` and add your FMP API key:
+
+   ```
+   cp env.example .env
+   # Edit .env and set FMP_API_KEY
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+Run the script to check today's earnings:
+
+```bash
+python positive_earnings.py
+```
+
+The script outputs all companies whose reported EPS is greater than the estimated EPS for today. If no companies beat expectations, it will state so.
+
+## Notes
+
+The Financial Modeling Prep API offers a free tier for limited requests. You can obtain an API key by creating an account on their website.

--- a/env.example
+++ b/env.example
@@ -1,0 +1,1 @@
+FMP_API_KEY=your_api_key_here

--- a/positive_earnings.py
+++ b/positive_earnings.py
@@ -1,0 +1,51 @@
+import os
+import requests
+from datetime import date
+
+API_URL = "https://financialmodelingprep.com/api/v3/earning_calendar"
+API_KEY = os.getenv("FMP_API_KEY")
+
+
+def fetch_earnings(target_date: date):
+    if API_KEY is None:
+        raise RuntimeError("FMP_API_KEY environment variable not set")
+
+    params = {
+        "from": target_date.isoformat(),
+        "to": target_date.isoformat(),
+        "apikey": API_KEY,
+    }
+    response = requests.get(API_URL, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def filter_positive_earnings(items):
+    positive = []
+    for item in items:
+        eps = item.get("eps")
+        eps_est = item.get("epsEstimated")
+        if eps is None or eps_est is None:
+            continue
+        if eps > eps_est:
+            positive.append(item)
+    return positive
+
+
+def main():
+    today = date.today()
+    earnings = fetch_earnings(today)
+    winners = filter_positive_earnings(earnings)
+    if not winners:
+        print(f"No positive earnings found for {today}")
+        return
+    print(f"Positive earnings for {today}:")
+    for item in winners:
+        symbol = item.get("symbol")
+        eps = item.get("eps")
+        eps_est = item.get("epsEstimated")
+        print(f"{symbol}: EPS {eps} beats estimate {eps_est}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- add `.gitignore` and Python dependency requirements
- provide a sample environment file for API key
- implement `positive_earnings.py` to fetch earnings and show companies beating estimates
- document setup and usage in the README

## Testing
- `pip install -r requirements.txt`
- `python positive_earnings.py` *(fails: 401 Client Error due to demo API key)*

------
https://chatgpt.com/codex/tasks/task_e_6847061601148329abf366aa860dce64