### PR TITLE
Switch to Nasdaq API without keys

### DIFF
--- a/.github/workflows/run-python.yml
+++ b/.github/workflows/run-python.yml
@@ -25,6 +25,5 @@ jobs:
 
     - name: Run Python Script
       run: |
-        export FMP_API_KEY=${{secrets.FMP_API_KEY}}
         python3 positive_earnings.py
     

--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # Stock Identifier
 
-This repository contains a small script that queries the [Financial Modeling Prep](https://financialmodelingprep.com/) API for companies releasing earnings on the current day and prints those that beat their EPS estimates.
+This repository contains a small script that queries Nasdaq's unofficial earnings calendar and earnings surprise endpoints (via a read-only proxy) to print companies reporting today that beat their EPS estimates. No API key is required.
 
 ## Setup
 
-1. Create a `.env` file based on `env.example` and add your FMP API key:
-
-   ```
-   cp env.example .env
-   # Edit .env and set FMP_API_KEY
-   ```
-
-2. Install dependencies:
+1. Install dependencies:
 
    ```bash
    pip install -r requirements.txt
@@ -29,4 +22,4 @@ The script outputs all companies whose reported EPS is greater than the estimate
 
 ## Notes
 
-The Financial Modeling Prep API offers a free tier for limited requests. You can obtain an API key by creating an account on their website.
+Data is fetched from Nasdaq's public endpoints using a proxy service. These endpoints are not officially supported and may change without notice.

--- a/env.example
+++ b/env.example
@@ -1,1 +1,1 @@
-FMP_API_KEY=your_api_key_here
+# No configuration needed

--- a/positive_earnings.py
+++ b/positive_earnings.py
@@ -1,49 +1,76 @@
-import os
 import requests
 from datetime import date
+import json
 
-API_URL = "https://financialmodelingprep.com/api/v3/earning_calendar"
-API_KEY = os.getenv("FMP_API_KEY")
+# Use Nasdaq's undocumented API via a read-only proxy to avoid API keys
+CALENDAR_URL = (
+    "https://r.jina.ai/https://api.nasdaq.com/api/calendar/earnings"
+)
+SURPRISE_URL = (
+    "https://r.jina.ai/https://api.nasdaq.com/api/company/{symbol}/earnings-surprise"
+)
 
 
 def fetch_earnings(target_date: date):
-    if API_KEY is None:
-        raise RuntimeError("FMP_API_KEY environment variable not set")
-
-    params = {
-        "from": target_date.isoformat(),
-        "to": target_date.isoformat(),
-        "apikey": API_KEY,
-    }
-    response = requests.get(API_URL, params=params, timeout=10)
-    response.raise_for_status()
-    return response.json()
+    """Return the earnings calendar for a specific date."""
+    params = {"date": target_date.isoformat()}
+    resp = requests.get(CALENDAR_URL, params=params, timeout=10, headers={"User-Agent": "python"})
+    resp.raise_for_status()
+    text = resp.text
+    start = text.find("{")
+    data = json.loads(text[start:])
+    return data.get("data", {}).get("rows", [])
 
 
-def filter_positive_earnings(items):
-    positive = []
-    for item in items:
-        eps = item.get("eps")
-        eps_est = item.get("epsEstimated")
-        if eps is None or eps_est is None:
+def fetch_surprises(symbol: str):
+    """Fetch historical earnings surprise data for a symbol."""
+    url = SURPRISE_URL.format(symbol=symbol)
+    resp = requests.get(url, timeout=10, headers={"User-Agent": "python"})
+    resp.raise_for_status()
+    text = resp.text
+    start = text.find("{")
+    data = json.loads(text[start:])
+    payload = data.get("data") or {}
+    table = payload.get("earningsSurpriseTable")
+    if not table:
+        return []
+    return table.get("rows", [])
+
+
+def filter_positive_earnings(target_date: date, calendar_rows):
+    """Return items where reported EPS beats the estimate on the target date."""
+    winners = []
+    date_str = f"{target_date.month}/{target_date.day}/{target_date.year}"
+    for entry in calendar_rows:
+        symbol = entry.get("symbol")
+        if not symbol:
             continue
-        if eps > eps_est:
-            positive.append(item)
-    return positive
+        for surprise in fetch_surprises(symbol):
+            if surprise.get("dateReported") != date_str:
+                continue
+            try:
+                eps = float(surprise.get("eps"))
+                est = float(surprise.get("consensusForecast"))
+            except (TypeError, ValueError):
+                break
+            if eps > est:
+                winners.append({"symbol": symbol, "eps": eps, "estimate": est})
+            break
+    return winners
 
 
 def main():
     today = date.today()
     earnings = fetch_earnings(today)
-    winners = filter_positive_earnings(earnings)
+    winners = filter_positive_earnings(today, earnings)
     if not winners:
         print(f"No positive earnings found for {today}")
         return
     print(f"Positive earnings for {today}:")
     for item in winners:
-        symbol = item.get("symbol")
-        eps = item.get("eps")
-        eps_est = item.get("epsEstimated")
+        symbol = item["symbol"]
+        eps = item["eps"]
+        eps_est = item["estimate"]
         print(f"{symbol}: EPS {eps} beats estimate {eps_est}")
 
 


### PR DESCRIPTION
## Summary
- drop Finnhub dependency and use Nasdaq's public calendar and earnings-surprise data
- remove environment variable usage and update README instructions
- simplify GitHub Actions workflow

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile positive_earnings.py`
- `python positive_earnings.py`

------
https://chatgpt.com/codex/tasks/task_e_684a014b14b48329bd60a1676561d8d7